### PR TITLE
Fix Button Dialog Fullscreen button

### DIFF
--- a/1080i/Includes_ButtonMenu.xml
+++ b/1080i/Includes_ButtonMenu.xml
@@ -85,7 +85,7 @@
                 <param name="itemgap">20</param>
                 <param name="bordersize">12</param>
                 <onclick>Close</onclick>
-                <onclick>Fullscreen</onclick>
+                <onclick>ToggleFullscreen</onclick>
                 <enable>Player.HasMedia</enable>
             </include>
         </control>


### PR DESCRIPTION
When using the options menu whilst playing media, the fullscreen button doesn't do anything when selected. This fixes that and toggles between windowed/full screen.