### PR TITLE
[gamesaves] Workaround for buggy gamewindow control

### DIFF
--- a/1080i/Includes_Layouts.xml
+++ b/1080i/Includes_Layouts.xml
@@ -273,6 +273,7 @@
                         <videofilter>$INFO[ListItem.Property(game.videofilter)]</videofilter>
                         <stretchmode>$INFO[ListItem.Property(game.stretchmode)]</stretchmode>
                         <rotation>$INFO[ListItem.Property(game.videorotation)]</rotation>
+                        <visible>String.IsEmpty(ListItem.Art(screenshot))</visible>
                     </control>
                     <control type="image">
                         <aspectratio>scale</aspectratio>
@@ -316,8 +317,6 @@
                     <height>30</height>
                 </control>
             </control>
-
-
         </definition>
     </include>
 


### PR DESCRIPTION
This feels like premature optimalisation, but doing this this way gets rid of the buggy gamewindow that's visible while scrolling during game saves. This will still bug for the other screens technically, but as they only contain 2 to 4 entries it will never scroll and trigger this issue.

Screenshot before:
![screenshot00001](https://github.com/jurialmunkey/skin.arctic.fuse/assets/1552365/d4ef1882-9527-4091-8839-6920c64d3ddf)


Screenshot after:
![screenshot00000](https://github.com/jurialmunkey/skin.arctic.fuse/assets/1552365/1598122b-1165-4a26-9374-0fb4ae3abb8e)
